### PR TITLE
Improve path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ for the set of available operations.
 
 ## Changelog
 
+### [2.1.1]
+
+- Improved path handling for temporary files (#7)
+
 ### [2.1.0]
 
 #### What's new?

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.nav</groupId>
     <artifactId>kafka-embedded-env</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <name>kafka-embedded-env</name>
     <description>Simple API for running a Kafka/Confluent environment locally</description>
     <url>https://github.com/navikt/kafka-embedded-env</url>

--- a/src/main/kotlin/no/nav/common/embeddedutils/functions.kt
+++ b/src/main/kotlin/no/nav/common/embeddedutils/functions.kt
@@ -1,16 +1,30 @@
 package no.nav.common.embeddedutils
 
-import java.io.IOException
 import java.net.ServerSocket
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
 
 /**
  * A function returning the next available socket port
  */
-fun getAvailablePort(): Int =
-        try {
-            ServerSocket(0).run {
-                reuseAddress = true
-                close()
-                localPort
-            }
-        } catch (e: IOException) { 0 } // TODO - watch out for this one
+fun getAvailablePort(): Int = ServerSocket(0).run {
+    reuseAddress = true
+    close()
+    localPort
+}
+
+fun deleteDir(dir: Path) {
+    if (Files.exists(dir)) {
+        Files.walk(dir).sorted(Comparator.reverseOrder()).forEach { Files.delete(it) }
+    }
+}
+
+private val tmpDir = Paths.get(System.getProperty("java.io.tmpdir"))
+
+fun appDirFor(appName: String): Path = tmpDir.resolve(appName)
+
+fun dataDirFor(path: Path): Path = path.resolve(UUID.randomUUID().toString()).apply {
+    Files.createDirectories(this)
+}


### PR DESCRIPTION
From trying to use kafka streams with embedded env we've encountered an issue with stream state not being deleted after tearDown, this is due to streams state being saved in another directory which is outside the temporary directories kafka-embedded-env creates. Since the state was saved we were having issues with the streams application recreating messages from earlier test runs and when using the current date we got unexpected results caused by older messages being re-read.

This PR also includes some minor changes to file handling:
* Use NIO Path and Files instead of File
* Don't silently fail on exceptions
* Make sure streams path is also deleted on failure
* Remove dependency to commons-io