### PR TITLE
Upgrade to Kafka 2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A simple API for creating an embedded Kafka environment with the KafkaEnvironment class, typically used for running integration tests. 
 
-Based on the [Confluent Open Source distribution](https://www.confluent.io/product/confluent-open-source/) v5.3.0. 
+Based on the [Confluent Open Source distribution](https://www.confluent.io/product/confluent-open-source/) v5.3.1. 
 
 Instead of using the classic ports (2181, 9092, ...) for each server, the class will get the required number of available ports 
 and use those in configurations for each server. 
@@ -51,7 +51,7 @@ Add the dependency:
 #### Gradle
 ```
 dependencies {
-    testImplementation "no.nav:kafka-embedded-env:2.2.3"
+    testImplementation "no.nav:kafka-embedded-env:2.3.0"
 }
 ```
 
@@ -60,7 +60,7 @@ dependencies {
 <dependency>
     <groupId>no.nav</groupId>
     <artifactId>kafka-embedded-env</artifactId>
-    <version>2.2.3</version>
+    <version>2.3.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -171,6 +171,10 @@ for the set of available operations.
 **Please close adminClient after use.**
 
 ## Changelog
+
+### [2.3.0]
+- Use Kafka 2.3.1
+- Use Confluent 5.3.1
 
 ### [2.2.3]
 - Increase default Zookeeper connection timeout from Kafka brokers in another attempt to remediate sporadically failing tests on slow machines

--- a/pom.xml
+++ b/pom.xml
@@ -3,21 +3,20 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.nav</groupId>
     <artifactId>kafka-embedded-env</artifactId>
-    <version>2.2.3</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>kafka-embedded-env</name>
     <description>Simple API for running a Kafka/Confluent environment locally</description>
     <url>https://github.com/navikt/kafka-embedded-env</url>
 
     <properties>
-        <kotlin.version>1.3.41</kotlin.version>
-        <kafka.version>2.3.0</kafka.version>
-        <ktor.version>1.2.1</ktor.version>
-        <confluent.version>5.3.0</confluent.version>
-        <commons.version>1.3.2</commons.version>
+        <kotlin.version>1.3.50</kotlin.version>
+        <kafka.version>2.3.1</kafka.version>
+        <ktor.version>1.2.5</ktor.version>
+        <confluent.version>5.3.1</confluent.version>
         <spek.version>2.0.5</spek.version>
         <kluent.version>1.52</kluent.version>
         <logback.version>1.2.3</logback.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.29</slf4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -112,12 +111,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-streams-avro-serde</artifactId>
             <version>${confluent.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumping a project to use Kafka 2.3.1 while using 2.2.3 (with Kafka 2.3.0) causes tests to hang, using 2.3.0-SNAPSHOT with kafka 2.3.1 on classpath works fine.

This commit therefore creates a version with Kafka 2.3.1