### PR TITLE
Enabling config overrides for Topics

### DIFF
--- a/src/main/kotlin/no/nav/common/KafkaEnvironment.kt
+++ b/src/main/kotlin/no/nav/common/KafkaEnvironment.kt
@@ -291,7 +291,7 @@ class KafkaEnvironment(
         val replFactor = this.brokers.size
 
         this.adminClient?.use { ac ->
-            ac.createTopics(topics.map { topic -> NewTopic(topic.name, topic.partitions, replFactor.toShort()) })
+            ac.createTopics(topics.map { topic -> NewTopic(topic.name, topic.partitions, replFactor.toShort()).configs(topic.config) })
         }
 
         topicsCreated = true


### PR DESCRIPTION
Topic config passed to `KafkaEnvironment.TopicDetails` was not being passed to `AdminClient.createTopics()` properly.
This PR adds a test case and fixes the problem.