### PR TITLE
Bump Kafka version to 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 
     <properties>
         <kotlin.version>1.3.61</kotlin.version>
-        <kafka.version>2.4.0</kafka.version>
+        <kafka.version>2.5.0</kafka.version>
         <ktor.version>1.2.5</ktor.version>
-        <confluent.version>5.4.0</confluent.version>
+        <confluent.version>5.5.0</confluent.version>
         <spek.version>2.0.9</spek.version>
         <kluent.version>1.52</kluent.version>
         <logback.version>1.2.3</logback.version>

--- a/src/main/kotlin/no/nav/common/embeddedzookeeper/ZKServer.kt
+++ b/src/main/kotlin/no/nav/common/embeddedzookeeper/ZKServer.kt
@@ -34,6 +34,7 @@ class ZKServer(override val port: Int, private val dataDir: Path, private val wi
             set("clientPort", "$port")
             set("maxClientCnxns", "0")
             set("4lw.commands.whitelist", "reqs,ruok")
+            set("admin.enableServer", "false")
             if (withSecurity) {
                 set("authProvider.1", "org.apache.zookeeper.server.auth.SASLAuthenticationProvider")
                 set("requireClientAuthScheme", "sasl")


### PR DESCRIPTION
-  Confluent version bumped to 5.5.0
- Added config to disable Zookeeper AdminServer, since it starts by default in ZK 3.5 and onwards
- Kafka libs bumped to 2.5


Unsure about release/version strategy so I didn't touch the version in the pom.
