### PR TITLE
3.2.2 + dep bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,29 +4,29 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.nav</groupId>
     <artifactId>kafka-embedded-env</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.2.2-SNAPSHOT</version>
     <name>kafka-embedded-env</name>
     <description>Simple API for running a Kafka/Confluent environment locally</description>
     <url>https://github.com/navikt/kafka-embedded-env</url>
 
     <properties>
-        <kotlin.version>1.6.21</kotlin.version>
-        <kafka.version>3.2.0</kafka.version>
-        <ktor.version>2.0.3</ktor.version>
+        <kotlin.version>1.7.10</kotlin.version>
+        <kafka.version>3.2.2</kafka.version>
+        <ktor.version>2.1.1</ktor.version>
         <confluent.version>7.2.1</confluent.version>
-        <spek.version>2.0.18</spek.version>
+        <spek.version>2.0.19</spek.version>
         <kluent.version>1.68</kluent.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <coroutines.version>1.6.1</coroutines.version>
+        <coroutines.version>1.6.4</coroutines.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.el.version>3.0.4</jakarta.el.version>
         <commons.collections4.version>4.4</commons.collections4.version>
-        <protobuf.java.version>3.20.1</protobuf.java.version>
+        <protobuf.java.version>3.20.2</protobuf.java.version>
         <javax.el.api.version>3.0.0</javax.el.api.version>
-        <netty.common.version>4.1.77.Final</netty.common.version>
-        <jackson-databind.version>2.13.3</jackson-databind.version>
+        <netty.common.version>4.1.81.Final</netty.common.version>
+        <jackson-databind.version>2.13.4</jackson-databind.version>
     </properties>
 
     <repositories>
@@ -118,6 +118,10 @@
                  <exclusion>
                      <groupId>org.glassfish</groupId>
                      <artifactId>jakarta.el</artifactId>
+                 </exclusion>
+                 <exclusion>
+                     <groupId>org.apache.kafka</groupId>
+                     <artifactId>kafka-clients</artifactId>
                  </exclusion>
              </exclusions>
          </dependency>


### PR DESCRIPTION
Added kafka-clients exclusion under kafka-schema-registry because it introduces 7.2.1-ccs.